### PR TITLE
Use pathlib for path concatenation and create cache/output folders

### DIFF
--- a/nemosis/gui.py
+++ b/nemosis/gui.py
@@ -10,6 +10,7 @@ import pickle
 import traceback
 import os
 import sys
+from pathlib import Path
 
 
 class VerticalScrollFrame(ttk.Frame):
@@ -230,6 +231,8 @@ class App(ttk.Frame):
         save_location = self.save_location.get()
         raw_data_location = self.raw_data_location.get()
         try:
+            Path(save_location).mkdir(parents=False, exist_ok=True)
+            Path(raw_data_location).mkdir(parents=False, exist_ok=True)
             for row in self.rows:
                 save_name = row.name.get()
                 if type(row).__name__ == 'Query':

--- a/nemosis/gui.py
+++ b/nemosis/gui.py
@@ -244,8 +244,8 @@ class App(ttk.Frame):
                 elif type(row).__name__ == 'FilterVersionNo':
                     results[save_name] = self.run_filter_version_no(row, results)
 
-                results[save_name].to_csv(save_location + '\\' + save_name + '.csv', index=False,
-                                          date_format='%Y/%m/%d %H:%M:%S')
+                results[save_name].to_csv(Path(save_location) / (save_name + '.csv'),
+                                          index=False, date_format='%Y/%m/%d %H:%M:%S')
             messagebox.showinfo('Finished', 'Your query has finished!')
         except Exception:
                 traceback.print_exc()


### PR DESCRIPTION
Thanks for the work on NEMOSIS, super handy!
I made a couple of changes while I was using this that I thought I'd share.
Let me know if these would be better in seperate PRs. 

On Mac the previous code didn't do path concatenation properly. E.g. if the output folder was ``~/op/`` then the output file would be ``op\queryname.csv`` in the ``~`` directory. I changed to using pathlib to abstract away path formatting for different OSs. This should also avoid issues with users putting a trailing slash in the inputs in the GUI, though I did't check if that's actually an issue.

I also made it create the output and cache folders if they didn't already exist.