### PR TITLE
Add DUALLOC table

### DIFF
--- a/nemosis/data_fetch_methods.py
+++ b/nemosis/data_fetch_methods.py
@@ -831,6 +831,7 @@ def _static_table_wrapper_for_gui(
 
 
 _method_map = {
+    "DUALLOC": _dynamic_data_wrapper_for_gui,
     "DISPATCHLOAD": _dynamic_data_wrapper_for_gui,
     "DISPATCHPRICE": _dynamic_data_wrapper_for_gui,
     "TRADINGLOAD": _dynamic_data_wrapper_for_gui,

--- a/nemosis/defaults.py
+++ b/nemosis/defaults.py
@@ -2,6 +2,7 @@ names = {
     "FCAS Providers": "NEM Registration and Exemption List.xls",
     "DISPATCHLOAD": "PUBLIC_DVD_DISPATCHLOAD",
     "NEXT_DAY_DISPATCHLOAD": "PUBLIC_NEXT_DAY_DISPATCHLOAD",
+    "DUALLOC": "PUBLIC_DVD_DUALLOC",
     "DUDETAILSUMMARY": "PUBLIC_DVD_DUDETAILSUMMARY",
     "DUDETAIL": "PUBLIC_DVD_DUDETAIL",
     "DISPATCHCONSTRAINT": "PUBLIC_DVD_DISPATCHCONSTRAINT",
@@ -40,6 +41,7 @@ table_types = {
     "FCAS Providers": "STATICXL",
     "DISPATCHLOAD": "MMS",
     "NEXT_DAY_DISPATCHLOAD": "NEXT_DAY_DISPATCHLOAD",
+    "DUALLOC": "MMS",
     "DUDETAILSUMMARY": "MMS",
     "DUDETAIL": "MMS",
     "DISPATCHCONSTRAINT": "MMS",
@@ -85,6 +87,7 @@ display_as_AMEO = [
     "FCAS Providers",
     "DISPATCHLOAD",
     "NEXT_DAY_DISPATCHLOAD",
+    "DUALLOC",
     "DUDETAILSUMMARY",
     "DUDETAIL",
     "DISPATCHCONSTRAINT",
@@ -140,6 +143,7 @@ fcas_4_url_hist = "http://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/F
 
 data_url = {
     "DISPATCHLOAD": "aemo_data_url",
+    "DUALLOC": "aemo_data_url",
     "DUDETAILSUMMARY": "aemo_data_url",
     "DUDETAIL": "aemo_data_url",
     "DISPATCHCONSTRAINT": "aemo_data_url",
@@ -213,6 +217,13 @@ filterable_cols = [
 ]
 
 table_columns = {
+    "DUALLOC": [
+        "EFFECTIVEDATE",
+        "VERSIONNO",
+        "DUID",
+        "GENSETID",
+        "LASTCHANGED",
+    ],
     "DISPATCHLOAD": [
         "SETTLEMENTDATE",
         "DUID",
@@ -661,6 +672,12 @@ table_columns = {
 }
 
 table_primary_keys = {
+    "DUALLOC": [
+        "DUID",
+        "EFFECTIVEDATE",
+        "GENSETID",
+        "VERSIONNO",
+    ],
     "DISPATCHCONSTRAINT": [
         "CONSTRAINTID",
         "GENCONID_EFFECTIVEDATE",
@@ -756,6 +773,7 @@ table_primary_keys = {
 }
 
 effective_date_group_col = {
+    "DUALLOC": ['DUID'],
     "SPDREGIONCONSTRAINT": ["GENCONID"],
     "SPDCONNECTIONPOINTCONSTRAINT": ["GENCONID"],
     "SPDINTERCONNECTORCONSTRAINT": ["GENCONID"],
@@ -773,6 +791,7 @@ effective_date_group_col = {
 }
 
 primary_date_columns = {
+    "DUALLOC": "EFFECTIVEDATE",
     "DISPATCHLOAD": "SETTLEMENTDATE",
     "NEXT_DAY_DISPATCHLOAD": "SETTLEMENTDATE",
     "TRADINGLOAD": "SETTLEMENTDATE",

--- a/nemosis/processing_info_maps.py
+++ b/nemosis/processing_info_maps.py
@@ -10,6 +10,7 @@ from nemosis import (
 
 
 setup = {
+    "DUALLOC": None,
     "DISPATCHLOAD": None,
     "NEXT_DAY_DISPATCHLOAD": None,
     "TRADINGLOAD": None,
@@ -46,6 +47,7 @@ setup = {
 }
 
 search_type = {
+    "DUALLOC": "end",
     "DISPATCHLOAD": "start_to_end",
     "NEXT_DAY_DISPATCHLOAD": "start_to_end",
     "TRADINGLOAD": "start_to_end",
@@ -82,6 +84,7 @@ search_type = {
 }
 
 date_cols = {
+    "DUALLOC": ["EFFECTIVEDATE"],
     "DISPATCHLOAD": ["SETTLEMENTDATE"],
     "NEXT_DAY_DISPATCHLOAD": ["SETTLEMENTDATE"],
     "TRADINGLOAD": ["SETTLEMENTDATE"],
@@ -118,6 +121,7 @@ date_cols = {
 }
 
 filter = {
+    "DUALLOC": filters.filter_on_effective_date,
     "DISPATCHLOAD": filters.filter_on_settlementdate,
     "NEXT_DAY_DISPATCHLOAD": filters.filter_on_settlementdate,
     "TRADINGLOAD": filters.filter_on_settlementdate,
@@ -154,6 +158,7 @@ filter = {
 }
 
 finalise = {
+    "DUALLOC": None,
     "DISPATCHLOAD": None,
     "NEXT_DAY_DISPATCHLOAD": None,
     "TRADINGLOAD": None,


### PR DESCRIPTION
Might help with PR: https://github.com/UNSW-CEEM/NEMOSIS/pull/28.

`DUALLOC` contains `GENSETID` as foreign key (primary key of `GENUNITS`).

`DUALLOC` contains the `DUID` field bridging relation between `GENUNITS` and family of dispatch /DUID tables.

Haven't had a chance to run change locally yet. Too many dependency errors on build. Hopefully you guys see no issues.