### PR TITLE
Updated column names in static_table

### DIFF
--- a/src/nemosis/defaults.py
+++ b/src/nemosis/defaults.py
@@ -646,7 +646,8 @@ table_columns = {
         "Technology Type - Descriptor",
         "Aggregation",
         "DUID",
-        "Reg Cap (MW)",
+        "Reg Cap generation (MW)",
+        "Max Cap generation (MW)"
     ],
     "FCAS Providers": [
         "Participant",


### PR DESCRIPTION
`static_table` produces an error when `"Generators and Scheduled Loads"` is passed to `table_name`.

It appears the column name "Reg Cap (MW)" has changed on the Participants Excel sheet (https://www.aemo.com.au/energy-systems/electricity/national-electricity-market-nem/participate-in-the-market/registration).

This fix removes the old column name for the new one, with an additional name for Maximum Capacity.

Reproduce error:
```
from nemosis import static_table

static_table(
    table_name="Generators and Scheduled Loads",
    raw_data_location="/path/to/dir/"
)
```