### PR TITLE
Housekeeping: README typo, deprecated pyproject field, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/*
 src/nemosis/__pycache__/*
 venv/*
+venv*/*
 build/*
 dist/*
 src/nemosis/build/*

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Choose the exe from the latest [release](https://github.com/UNSW-CEEM/NEMOSIS/re
 
 ## Contributing
 
-Interested in contributing? Check out the [contributing instructions](./CONTRIBUTING. md), which also includes steps to install `nemosis` for development.
+Interested in contributing? Check out the [contributing instructions](./CONTRIBUTING.md), which also includes steps to install `nemosis` for development.
 
 Please note that this project is released with a [Code of Conduct](./CONDUCT.md). By contributing to this project, you agree to abide by its terms.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 managed = true
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "parameterized>=0.9.0",
     "pyinstaller>=6.11.1",
     "pytest>=8.3.4",


### PR DESCRIPTION
## Summary
Three small housekeeping commits cherry-picked from #67 so they can land independently of the larger features in that PR.

- `Fix typo in README` — extra space in `CONTRIBUTING. md` link
- `Update deprecated field in pyproject.toml` — move dev deps from the deprecated `[tool.uv] dev-dependencies` to PEP 735 `[dependency-groups] dev`
- `tweak gitignore for creative venv names` — add `venv*/*` so `venv-3.13/` etc. are ignored

All three commits are by Matthew Davis (@mdavis-xyz), preserved via cherry-pick.

## Test plan
- [ ] No source code touched; nothing to run
- [ ] Confirm `uv lock` is a no-op (PEP 735 `[dependency-groups]` is uv's recommended replacement for `[tool.uv] dev-dependencies` and resolves identically) — verified locally, `uv.lock` unchanged
- [ ] CI green