### PR TITLE
Reject raw_data_location=None with a clear UserInputError

### DIFF
--- a/src/nemosis/data_fetch_methods.py
+++ b/src/nemosis/data_fetch_methods.py
@@ -63,6 +63,10 @@ def dynamic_data_compiler(
     Returns:
         all_data (pd.Dataframe): All data concatenated.
     """
+
+    if raw_data_location is None:
+        raise UserInputError("The raw_data_location provided is None.")
+
     if not _os.path.isdir(raw_data_location):
         raise UserInputError("The raw_data_location provided does not exist.")
 
@@ -186,6 +190,10 @@ def cache_compiler(
     Returns:
         Nothing
     """
+    
+    if raw_data_location is None:
+        raise UserInputError("The raw_data_location provided is None.")
+
     if not _os.path.isdir(raw_data_location):
         raise UserInputError("The raw_data_location provided does not exist.")
 

--- a/src/nemosis/data_fetch_methods.py
+++ b/src/nemosis/data_fetch_methods.py
@@ -270,6 +270,9 @@ def static_table(
     Returns:
         data (pd.Dataframe)
     """
+    if raw_data_location is None:
+        raise UserInputError("The raw_data_location provided is None.")
+
     if not _os.path.isdir(raw_data_location):
         raise UserInputError("The raw_data_location provided does not exist.")
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -71,6 +71,17 @@ def test_dynamic_select_columns_all_requires_csv(nemosis_fixture):
         )
 
 
+def test_dynamic_raw_data_location_is_none():
+    """Passing None as the cache path is a common caller mistake (forgot
+    to set it, config returned None). Reject with UserInputError rather
+    than the cryptic TypeError that os.path.isdir(None) would raise."""
+    with pytest.raises(UserInputError, match="is None"):
+        dynamic_data_compiler(
+            "2018/05/01 00:00:00", "2018/05/01 01:00:00",
+            "DISPATCHPRICE", raw_data_location=None,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Argument-validation: cache_compiler
 # ---------------------------------------------------------------------------
@@ -102,6 +113,14 @@ def test_cache_select_columns_requires_rebuild(nemosis_fixture):
         )
 
 
+def test_cache_raw_data_location_is_none():
+    with pytest.raises(UserInputError, match="is None"):
+        cache_compiler(
+            "2018/05/01 00:00:00", "2018/05/01 01:00:00",
+            "DISPATCHPRICE", raw_data_location=None,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Argument-validation: static_table
 # ---------------------------------------------------------------------------
@@ -119,6 +138,11 @@ def test_static_filter_col_not_in_select_columns(nemosis_fixture):
             filter_cols=["VARIABLETYPE"],
             filter_values=(["MW"],),
         )
+
+
+def test_static_raw_data_location_is_none():
+    with pytest.raises(UserInputError, match="is None"):
+        static_table("VARIABLES_FCAS_4_SECOND", raw_data_location=None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Salvages the one source-side improvement from #67's test-triage bundle that survived PR #72 — explicit `None` check on `raw_data_location` in all three public entrypoints. Today, passing `None` falls through to `os.path.isdir(None)` and raises `TypeError` from the stdlib, with a message that doesn't mention the parameter. Now it raises `UserInputError` (the library's contract for caller-input mistakes) with a message that names the parameter.

Two commits:

- **`Reject raw_data_location=None with a clear UserInputError`** (author: @mdavis-xyz) — cherry-picked from #67 commit `7e71e73`, source change only. Adds the check to `dynamic_data_compiler` and `cache_compiler`. The companion `tests/test_00_test_setup.py` from the original commit is dropped: it asserted `defaults.raw_data_cache` is set via the `NEMOSIS_TEST_CACHE` env var, which #72 obsoleted by moving to fixture-scoped temp dirs via `nemosis_fixture`.
- **`Extend None-check to static_table and add regression tests`** (author: me) — applies the same check to `static_table` (the original commit didn't, but it has the same `_os.path.isdir` line and the same UX flaw), and adds one regression test per entrypoint to `tests/test_errors.py`.

## Context — what else is left from PR #67's test triage

Audited all six test commits from #67 against post-#72 master:

| #67 commit | Verdict |
|---|---|
| `dd01b63` skip cache-purging tests (#16) | Redundant — target `tests/test_format_options.py` deleted by #72 |
| `e3dbef5` skip FCAS_4_SECOND tests (#64) | Redundant — target `tests/test_data_fetch_methods.py` deleted; no live-AEMO FCAS tests left |
| `397bdf8` un-hardcode cache path | Redundant — target `tests/test_errors_and_warnings.py` deleted; new `test_errors.py` uses fixture path |
| `fea56a0` skip long processing_info_maps tests | Redundant — `test_processing_info_maps.py` rewritten by #72, now offline + fast |
| `7e71e73` cache-path robustness | **This PR** — source change kept, test file dropped |
| `238fd35` typo fix in `test_00_test_setup.py` | Redundant — applied to the file we're dropping |

## Test plan

- [x] `uv run pytest tests/test_errors.py` — 16/16 pass (13 pre-existing + 3 new)
- [ ] CI green