### PR TITLE
Rename download_xl → download_xlsx, drop dead dict keys

### DIFF
--- a/src/nemosis/data_fetch_methods.py
+++ b/src/nemosis/data_fetch_methods.py
@@ -446,8 +446,7 @@ def _finalise_csv_data(data, table_name):
 static_downloader_map = {
     "VARIABLES_FCAS_4_SECOND": _downloader.download_csv,
     "ELEMENTS_FCAS_4_SECOND": _downloader.download_elements_file,
-    "Generators and Scheduled Loads": _downloader.download_xl,
-    "_downloader.download_xl": _downloader.download_xl,
+    "Generators and Scheduled Loads": _downloader.download_xlsx,
 }
 
 static_file_reader_map = {

--- a/src/nemosis/defaults.py
+++ b/src/nemosis/defaults.py
@@ -134,7 +134,6 @@ static_table_url = {
     "ELEMENTS_FCAS_4_SECOND": "https://www.nemweb.com.au/Reports/Current/Causer_Pays_Elements/",
     "VARIABLES_FCAS_4_SECOND": "https://aemo.com.au/-/media/files/electricity/nem/settlements_and_payments/settlements/auction-reports/archive/ancillary-services-market-causer-pays-variables-file.csv",
     "Generators and Scheduled Loads": "https://www.aemo.com.au/-/media/files/electricity/nem/Participant_Information/NEM-Registration-and-Exemption-List.xlsx",
-    "_downloader.download_xl": "https://www.aemo.com.au/-/media/files/electricity/nem/Participant_Information/NEM-Registration-and-Exemption-List.xlsx",
 }
 
 aemo_mms_url = "http://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/{}/MMSDM_{}_{}/MMSDM_Historical_Data_SQLLoader/DATA/{}.zip"

--- a/src/nemosis/downloader.py
+++ b/src/nemosis/downloader.py
@@ -280,10 +280,10 @@ def download_elements_file(url, path_and_name):
         f.write(r.content)
 
 
-def download_xl(url, path_and_name):
+def download_xlsx(url, path_and_name):
     """
-    This function downloads a zipped csv using a url, extracts the csv and
-    saves it a specified location
+    Download an Excel (.xlsx) file from a URL and save it to the
+    specified path. Used for AEMO's NEM Registration and Exemption List.
     """
     r = requests.get(url, headers=USR_AGENT_HEADER)
     with open(path_and_name, "wb") as f:


### PR DESCRIPTION
## Summary

Completes the xls→xlsx work begun by #60. The filename + URL pieces (`.xls` → `.xlsx`) landed in master via PR #72's `ebf27ea`. This PR cleans up the three remaining items that PR #72 didn't address:

1. **Rename `downloader.download_xl` → `download_xlsx`.** The function downloads AEMO's NEM Registration and Exemption List, which is now a `.xlsx` file. The old "xl" name was ambiguous; "xlsx" matches what's on the wire.

   PR #67's `e5cac94` (bundled inside the Session refactor) renamed it to `download_xml` — but that's wrong, the file isn't XML. This PR takes Matt's intended rename and uses the correct name instead.

2. **Fix the docstring**, which claimed:

   > "This function downloads a zipped csv using a url, extracts the csv and saves it a specified location"

   The function body is just `requests.get` + `f.write(r.content)` — no zip, no CSV, no extraction. Replaced with what it actually does.

3. **Remove two dead entries** keyed by the literal string `"_downloader.download_xl"`:

   - `defaults.static_table_url["_downloader.download_xl"]`
   - `data_fetch_methods.static_downloader_map["_downloader.download_xl"]`

   Both dicts are looked up by table name (e.g. `"Generators and Scheduled Loads"`, `"VARIABLES_FCAS_4_SECOND"`) — nothing ever queries them with a Python identifier as the key. `git grep` confirms no consumers. PR #72's xlsx fix just updated the URL value of the dead defaults entry to keep it consistent; this drops both entries entirely.

## Authorship note

Written from scratch by me rather than cherry-picked, because PR #67's rename was bundled inside the Session refactor (`e5cac94`, a 387-line downloader rewrite) and the rename target name (`download_xml`) was wrong. The intent is Matt's; the corrected implementation is mine.

## Test plan

- [x] `uv run pytest tests/end_to_end_table_tests/test_static_tables.py` — all 8 pass (these exercise the renamed function path via the offline mock server)
- [x] `uv run pytest tests/` — 371 pass, 1 skipped, 1 pre-existing unrelated warning
- [ ] CI green

Related: #60 (closed by PR #72's `ebf27ea`; this completes the surrounding cleanup).