### PR TITLE
Adopt requests.Session, bump UA to Chrome 130, raise_for_status everywhere

### DIFF
--- a/src/nemosis/defaults.py
+++ b/src/nemosis/defaults.py
@@ -137,7 +137,7 @@ static_table_url = {
     "_downloader.download_xl": "https://www.aemo.com.au/-/media/files/electricity/nem/Participant_Information/NEM-Registration-and-Exemption-List.xlsx",
 }
 
-aemo_mms_url = "http://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/{}/MMSDM_{}_{}/MMSDM_Historical_Data_SQLLoader/DATA/{}.zip"
+aemo_mms_url = "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/{}/MMSDM_{}_{}/MMSDM_Historical_Data_SQLLoader/DATA/{}.zip"
 
 current_data_page_urls = {
     "BIDDING": "Reports/Current/Bidmove_Complete/",
@@ -146,9 +146,9 @@ current_data_page_urls = {
     "INTERMITTENT_GEN_SCADA": "/Reports/Current/Next_Day_Intermittent_Gen_Scada/"
 }
 
-fcas_4_url = "http://www.nemweb.com.au/Reports/Current/Causer_Pays/FCAS_{}{}{}{}.zip"
+fcas_4_url = "https://www.nemweb.com.au/Reports/Current/Causer_Pays/FCAS_{}{}{}{}.zip"
 
-fcas_4_url_hist = "http://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/FCAS_Causer_Pays/{}/FCAS_Causer_Pays_{}_{}/FCAS_{}{}{}{}.zip"
+fcas_4_url_hist = "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/FCAS_Causer_Pays/{}/FCAS_Causer_Pays_{}_{}/FCAS_{}{}{}{}.zip"
 
 data_url = {
     "DISPATCHLOAD": "aemo_data_url",

--- a/src/nemosis/downloader.py
+++ b/src/nemosis/downloader.py
@@ -10,14 +10,21 @@ from . import defaults, custom_errors
 
 logger = logging.getLogger(__name__)
 
-# Windows Chrome for User-Agent request headers
-USR_AGENT_HEADER = {
+# Module-level requests.Session for connection reuse across the many
+# small downloads NEMOSIS makes when scanning monthly archives. The
+# session also centralises the User-Agent so every request looks like a
+# current Windows Chrome — AEMO's `aemo.com.au` host filters out older
+# UAs as suspected scrapers, and `nemweb.com.au` is happy either way.
+# Chrome 130 was the current stable when this was written; bump
+# periodically to stay plausible.
+session = requests.Session()
+session.headers.update({
     "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-        + " AppleWebKit/537.36 (KHTML, like Gecko) "
-        + "Chrome/80.0.3987.87 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/130.0.0.0 Safari/537.36"
     )
-}
+})
 
 
 def run(year, month, day, chunk, index, filename_stub, down_load_to):
@@ -95,7 +102,8 @@ def _get_current_url(filename_stub, current_page_url):
 def _download_and_unpack_bid_move_complete_files(
     download_url, down_load_to
 ):
-    r = requests.get(download_url, headers=USR_AGENT_HEADER)
+    r = session.get(download_url)
+    r.raise_for_status()
     zipped_file = zipfile.ZipFile(io.BytesIO(r.content))
 
     file_name = zipped_file.namelist()[
@@ -131,7 +139,8 @@ def _download_and_unpack_bid_move_complete_files(
 def _download_and_unpack_next_region_tables(
     download_url, down_load_to
 ):
-    r = requests.get(download_url, headers=USR_AGENT_HEADER)
+    r = session.get(download_url)
+    r.raise_for_status()
     zipped_file = zipfile.ZipFile(io.BytesIO(r.content))
 
     file_name = zipped_file.namelist()[
@@ -160,7 +169,8 @@ def _download_and_unpack_next_region_tables(
 def _download_and_unpack_next_dispatch_load_files_complete_files(
     download_url, down_load_to
 ):
-    r = requests.get(download_url, headers=USR_AGENT_HEADER)
+    r = session.get(download_url)
+    r.raise_for_status()
     zipped_file = zipfile.ZipFile(io.BytesIO(r.content))
 
     file_name = zipped_file.namelist()[
@@ -185,7 +195,8 @@ def _download_and_unpack_next_dispatch_load_files_complete_files(
 def _download_and_unpack_intermittent_gen_scada_file(
     download_url, down_load_to
 ):
-    r = requests.get(download_url, headers=USR_AGENT_HEADER)
+    r = session.get(download_url)
+    r.raise_for_status()
     zipped_file = zipfile.ZipFile(io.BytesIO(r.content))
 
     file_name = zipped_file.namelist()[
@@ -253,7 +264,8 @@ def download_unzip_csv(url, down_load_to):
     extracts the csv and saves it a specified location
     """
     url = url.replace('#', '%23')
-    r = requests.get(url, headers=USR_AGENT_HEADER)
+    r = session.get(url)
+    r.raise_for_status()
     z = zipfile.ZipFile(io.BytesIO(r.content))
     z.extractall(down_load_to)
 
@@ -263,19 +275,21 @@ def download_csv(url, path_and_name):
     This function downloads a zipped csv using a url,
     extracts the csv and saves it a specified location
     """
-    r = requests.get(url, headers=USR_AGENT_HEADER)
+    r = session.get(url)
+    r.raise_for_status()
     with open(path_and_name, "wb") as f:
         f.write(r.content)
 
 
 def download_elements_file(url, path_and_name):
-    page = requests.get(url)
-    text = page.text
-    soup = BeautifulSoup(text, "html.parser")
+    page = session.get(url)
+    page.raise_for_status()
+    soup = BeautifulSoup(page.text, "html.parser")
     links = soup.find_all("a")
     last_file_name = links[-1].text
     link = url + last_file_name
-    r = requests.get(link, headers=USR_AGENT_HEADER)
+    r = session.get(link)
+    r.raise_for_status()
     with open(path_and_name, "wb") as f:
         f.write(r.content)
 
@@ -285,7 +299,8 @@ def download_xl(url, path_and_name):
     This function downloads a zipped csv using a url, extracts the csv and
     saves it a specified location
     """
-    r = requests.get(url, headers=USR_AGENT_HEADER)
+    r = session.get(url)
+    r.raise_for_status()
     with open(path_and_name, "wb") as f:
         f.write(r.content)
 
@@ -301,12 +316,13 @@ def format_aemo_url(url, year, month, filename_stub):
 
 
 def status_code_return(url):
-    r = requests.get(url, headers=USR_AGENT_HEADER)
+    r = session.get(url)
     return r.status_code
 
 
 def _get_matching_link(url, stub_link):
-    r = requests.get(url, headers=USR_AGENT_HEADER)
+    r = session.get(url)
+    r.raise_for_status()
     soup = BeautifulSoup(r.content, "html.parser")
     links = [link.get("href") for link in soup.find_all("a")]
     for link in links:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,60 @@
+"""Unit tests for the downloader's HTTP layer.
+
+These tests cover contracts introduced when adopting `requests.Session`:
+
+1. Every download function raises `requests.HTTPError` on non-2xx
+   responses rather than silently propagating garbled bytes into a
+   downstream parser (e.g. zipfile choking on a 404 HTML page).
+2. The shared `session` has a plausibly-current Chrome User-Agent.
+   AEMO's `aemo.com.au` host filters out stale UAs as scrapers, so
+   this matters for the registration-list endpoint in particular.
+
+Tests use the `aemo_mock_server` fixture directly so they hit a real
+HTTP server (in-process) and exercise the actual `requests` code path
+— not a monkeypatch on the function under test.
+"""
+import tempfile
+
+import pytest
+import requests
+
+from nemosis import downloader
+
+
+def test_session_user_agent_claims_current_chrome():
+    """Lock in the contract that the session's default UA looks like a
+    current Chrome. Bumping the version requires updating this test;
+    that's intentional — it forces a conscious decision."""
+    ua = downloader.session.headers["User-Agent"]
+    assert "Chrome/130" in ua, ua
+    assert "Mozilla/5.0" in ua, ua
+
+
+def test_download_unzip_csv_raises_on_404(aemo_mock_server):
+    """Before this contract, a 404 (e.g. archive doesn't exist for a
+    month) was caught downstream when `zipfile.ZipFile` choked on the
+    404 HTML response with `BadZipFile` — a confusing error that
+    obscured the real cause. Now HTTPError surfaces directly."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(requests.HTTPError):
+            downloader.download_unzip_csv(
+                f"{aemo_mock_server}/does/not/exist.zip", tmp
+            )
+
+
+def test_download_csv_raises_on_404(aemo_mock_server):
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(requests.HTTPError):
+            downloader.download_csv(
+                f"{aemo_mock_server}/does/not/exist.csv",
+                f"{tmp}/out.csv",
+            )
+
+
+def test_download_xl_raises_on_404(aemo_mock_server):
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(requests.HTTPError):
+            downloader.download_xl(
+                f"{aemo_mock_server}/does/not/exist.xlsx",
+                f"{tmp}/out.xlsx",
+            )


### PR DESCRIPTION
## Summary

First of three sequential PRs implementing the downloader rework from #67. This one is the foundation — purely structural changes to the HTTP layer, no new dependencies, no new code paths.

| Change | Why |
|---|---|
| Module-level `requests.Session` replaces ad-hoc `requests.get(...)` | Connection reuse across the many small downloads in a query (~12+ monthly zips for a typical fetch). Saves a TCP+TLS handshake per request after the first. Headers set once, not threaded through every call site. |
| Default `User-Agent` bumped from Chrome 80 → Chrome 130 | Chrome 80 dates from early 2020. AEMO's `aemo.com.au` host (where the participant registration `.xlsx` lives) filters out stale UAs as suspected scrapers, and a 6-year-old UA string increasingly fails that filter. |
| `raise_for_status()` on every download response | Today a 404 propagates as a confusing `BadZipFile` when `zipfile.ZipFile` chokes on the 404 HTML body. The outer `except Exception:` in `run()` / `run_bid_tables()` / etc. catches both, so this is a **clarity change, not a behaviour change** — failed downloads still log a warning and continue; they just produce a sensible exception class in the trace. |
| 3 URL templates flipped `http://www.nemweb.com.au` → `https://...` | nemweb has supported HTTPS for years; AEMO's CDN redirects http→https anyway, costing an extra round trip per request. |

## Departures from #67

PR #67's `e5cac94` kept Chrome 80 as the session default and overrode per-request to Chrome 130 only for `aemo.com.au` URLs. This PR uses **uniform Chrome 130** instead — same goal (a current UA for the picky endpoint), simpler code (no per-request `headers={}` dict, no `urlparse` of the URL). nemweb.com.au gets a fresher UA too, but they don't UA-filter so there's no risk.

PR #67 also bundled the streamed-downloads work, the TTL-cached HTML pre-check, and the `download_xl → download_xml` rename into the same commit. Those are deferred to follow-up PRs (and the rename was already corrected to `download_xlsx` in #84).

## What's coming next in the queue

- **PR-B**: streamed downloads + cleanup-on-failure (`download_to_path` helper, `stream=True, iter_content`)
- **PR-C**: TTL-cached HTML pre-check + `cachetools>=7` dep + `_pre_check_file_is_missing` for fast 404-skipping when scanning back into history

Each builds on this one's Session.

## Live smoke-tested against real AEMO and nemweb

The whole point of this PR (Chrome 130 UA + HTTPS to nemweb + raise_for_status) only matters in the wild — offline tests can verify the code paths but not the actual server behaviour. Four targeted smoke tests run against real services on this branch:

| Test | Result |
|---|---|
| Download AEMO registration `.xlsx` via `download_xl` | ✅ Chrome 130 accepted, 779 KB in 0.46s |
| Download a 2024-07 MMS zip via `download_unzip_csv` over HTTPS | ✅ 16 MB CSV extracted in 1.07s |
| Hit a known-404 nemweb path | ✅ Cleanly surfaces as `HTTPError: 404 Client Error` (not the previous `BadZipFile`) |
| End-to-end `dynamic_data_compiler` for 30 min of recent DISPATCHPRICE | ✅ 30 rows × 13 cols across all 5 regions |

## Pre-existing bug surfaced (not in scope here)

The smoke testing surfaced #74 — `PUBLIC_ARCHIVE#…` format URLs (2024-08+) are wrongly encoded in `download_unzip_csv` (single `%23` instead of the double `%2523` that real nemweb expects). Diagnosed and root-cause documented in https://github.com/UNSW-CEEM/NEMOSIS/issues/74#issuecomment-4531210638. **Not introduced by this PR** — same encoding code on master pre-this-PR — so it doesn't gate #85. Tracked as a follow-up.

## Test plan

- [x] `uv run pytest tests/test_downloader.py` — 4/4 new tests pass
- [x] `uv run pytest tests/` — 382 pass, 1 skipped, 1 pre-existing unrelated warning
- [x] Live smoke tests against real AEMO + nemweb (table above)
- [ ] CI green

### What the new unit tests cover

- `test_session_user_agent_claims_current_chrome` — locks in the Chrome 130 string. Bumping the UA later requires updating this test, which is deliberate friction.
- `test_download_unzip_csv_raises_on_404`, `test_download_csv_raises_on_404`, `test_download_xl_raises_on_404` — confirm the three main download functions raise `requests.HTTPError` on non-2xx responses, using the offline `aemo_mock_server` fixture to hit real-but-missing paths.