### PR TITLE
Cache parent directory HTML for fast missing-file pre-check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "xlrd>=2.0.1",
     "beautifulsoup4>=4.12.3",
     "openpyxl>=3.1.5",
+    "cachetools>=5.5.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/src/nemosis/downloader.py
+++ b/src/nemosis/downloader.py
@@ -4,7 +4,10 @@ import requests
 from bs4 import BeautifulSoup
 import zipfile
 import io
+from urllib.parse import urljoin, urldefrag
+
 import pandas as pd
+from cachetools import cached, TTLCache
 
 from . import defaults, custom_errors
 
@@ -25,6 +28,76 @@ session.headers.update({
         "Chrome/130.0.0.0 Safari/537.36"
     )
 })
+
+
+# ---------------------------------------------------------------------------
+# Parent-directory HTML cache (powers the missing-file pre-check below)
+# ---------------------------------------------------------------------------
+#
+# Scanning historical NEMOSIS data hits many monthly archive paths that
+# don't yet exist — each one normally costs a ~200-500ms 404 round-trip
+# to nemweb. Nemweb serves a browsable HTML index for each archive
+# directory, so we can fetch the parent listing once and answer many
+# missing-file questions from it without further network traffic.
+#
+# 1-hour TTL is long enough to amortise across a multi-year scan, short
+# enough that re-running an hour later sees fresh state. The cache is
+# exposed at module scope so tests can clear it between cases — see the
+# autouse `_clear_downloader_html_cache` fixture in tests/conftest.py.
+_html_cache: TTLCache = TTLCache(maxsize=2**10, ttl=60 * 60)
+
+# Nemweb's directory-listed archive trees. Other AEMO endpoints (e.g.
+# the hashed PUBLIC_ARCHIVE# files under aemo_mms_url) don't have a
+# browsable parent, so the pre-check sits this out for them.
+_NEMWEB_HTML_PRECHECK_PREFIXES = (
+    "https://www.nemweb.com.au/Data_Archive/",
+    "https://www.nemweb.com.au/Reports/",
+)
+
+
+@cached(_html_cache)
+def download_html(url):
+    """Fetch `url` and return its body as text. Cached at module scope
+    for ~1 hour — see `_html_cache` for the rationale."""
+    r = session.get(url)
+    r.raise_for_status()
+    return r.text
+
+
+def download_html_as_soup(url):
+    """BeautifulSoup-parsed view of `url`'s HTML body. Backed by the
+    same TTL cache as `download_html`."""
+    return BeautifulSoup(download_html(url), "html.parser")
+
+
+def _pre_check_file_is_missing(file_url):
+    """Return True if `file_url`'s parent directory listing is reachable
+    and the file is NOT linked from it, False if it IS linked, or None
+    when no parent listing is available (non-nemweb URL, non-archive
+    file extension, parent fetch failed, etc).
+
+    A True answer lets the caller skip a guaranteed-404 round-trip.
+    A None answer means the caller should fall through to a real
+    request and let any 404 surface the normal way.
+    """
+    if not any(file_url.startswith(prefix) for prefix in _NEMWEB_HTML_PRECHECK_PREFIXES):
+        return None
+    if not (file_url.upper().endswith(".ZIP") or file_url.upper().endswith(".CSV")):
+        return None
+
+    parent_url = urljoin(file_url, "./")
+    try:
+        soup = download_html_as_soup(parent_url)
+    except Exception:
+        # Parent listing unreachable — fall through to a real request.
+        return None
+
+    target = urldefrag(file_url)[0]
+    for a_tag in soup.find_all("a", href=True):
+        absolute = urljoin(parent_url, a_tag["href"])
+        if urldefrag(absolute)[0] == target:
+            return False
+    return True
 
 
 def run(year, month, day, chunk, index, filename_stub, down_load_to, keep_zip=False):
@@ -301,6 +374,20 @@ def download_to_path(url, path_and_name, force_redo=False):
     if os.path.isfile(path_and_name) and not force_redo:
         return False
 
+    if _pre_check_file_is_missing(url):
+        # The parent directory's HTML listing told us this file doesn't
+        # exist. Synthesise a 404 HTTPError so the caller's existing 404
+        # handling (added in PR #85) fires uniformly whether the answer
+        # came from the cache or the wire.
+        synthetic = requests.Response()
+        synthetic.status_code = 404
+        synthetic.reason = "Not Found (cached parent directory listing)"
+        synthetic.url = url
+        raise requests.HTTPError(
+            f"404 Client Error: {synthetic.reason} for url: {url}",
+            response=synthetic,
+        )
+
     with session.get(url, stream=True) as response:
         response.raise_for_status()
         try:
@@ -348,9 +435,7 @@ def download_csv(url, path_and_name):
 
 
 def download_elements_file(url, path_and_name):
-    page = session.get(url)
-    page.raise_for_status()
-    soup = BeautifulSoup(page.text, "html.parser")
+    soup = download_html_as_soup(url)
     links = soup.find_all("a")
     last_file_name = links[-1].text
     link = url + last_file_name
@@ -381,9 +466,7 @@ def status_code_return(url):
 
 
 def _get_matching_link(url, stub_link):
-    r = session.get(url)
-    r.raise_for_status()
-    soup = BeautifulSoup(r.content, "html.parser")
+    soup = download_html_as_soup(url)
     links = [link.get("href") for link in soup.find_all("a")]
     for link in links:
         if stub_link in link:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,30 @@ from pathlib import Path
 
 import pytest
 
-from nemosis import defaults
+from nemosis import defaults, downloader
 
 
 # NEMOSIS's own INFO/DEBUG logs leak into test output and clutter failure
 # context. Silence anything below WARNING — genuinely surprising conditions
 # (e.g. a 404 on a file we expected to fixture) still surface.
 logging.getLogger("nemosis").setLevel(logging.WARNING)
+
+
+# ---------------------------------------------------------------------------
+# Cache hygiene
+# ---------------------------------------------------------------------------
+#
+# The downloader's parent-directory HTML cache is module-level state with
+# a 1-hour TTL — fine in production, a bug magnet in tests because results
+# leak across cases (test A fetches a real listing, test B monkeypatches
+# `_NEMWEB_HTML_PRECHECK_PREFIXES` and gets stale cached HTML from A).
+# Clear it at every test boundary so each test starts cold.
+
+@pytest.fixture(autouse=True)
+def _clear_downloader_html_cache():
+    downloader._html_cache.clear()
+    yield
+    downloader._html_cache.clear()
 
 FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "data"
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -132,3 +132,153 @@ def test_download_to_dir_forwards_force_redo(aemo_mock_server, tmp_path):
         "force_redo=True should re-download; if this fails, download_to_dir "
         "may have stopped forwarding force_redo to download_to_path"
     )
+
+
+# ---------------------------------------------------------------------------
+# TTL-cached parent-directory HTML pre-check
+#
+# Scanning back into pre-2015 history hits many monthly archive paths that
+# 404. Each one was a 200-500ms round-trip. We now fetch each parent
+# directory's HTML index once, cache it for ~1 hour, and answer most
+# missing-file questions locally. These tests cover:
+# 1. download_html caches across calls
+# 2. _pre_check_file_is_missing returns False / True / None correctly
+# 3. download_to_path surfaces a missing-file pre-check as HTTPError(404)
+# 4. URLs outside the nemweb archive paths are not affected (no regression
+#    on the existing mock-server-driven test suite)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _patch_precheck_prefixes(aemo_mock_server, monkeypatch):
+    """Re-point the pre-check prefix list at the local mock server so we
+    can exercise the nemweb-only code path against fixtures."""
+    monkeypatch.setattr(
+        downloader, "_NEMWEB_HTML_PRECHECK_PREFIXES", (aemo_mock_server + "/",)
+    )
+
+
+def test_download_html_caches_across_calls(aemo_mock_server, monkeypatch):
+    """A second call for the same URL should be served from the TTL cache
+    rather than hitting the network. We instrument session.get to count
+    real fetches."""
+    url = f"{aemo_mock_server}/"
+    real_get = downloader.session.get
+    call_count = 0
+
+    def counting_get(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return real_get(*args, **kwargs)
+
+    monkeypatch.setattr(downloader.session, "get", counting_get)
+
+    first = downloader.download_html(url)
+    second = downloader.download_html(url)
+
+    assert first == second
+    assert call_count == 1, (
+        f"download_html should cache; saw {call_count} network calls for 2 lookups"
+    )
+
+
+def test_pre_check_returns_none_for_non_nemweb_urls():
+    """URLs outside the nemweb archive prefixes get None so callers fall
+    through to a real request — protects every existing test that points
+    NEMOSIS at the local mock server (which doesn't match the prefix)."""
+    assert downloader._pre_check_file_is_missing("http://127.0.0.1:1234/foo.zip") is None
+    assert downloader._pre_check_file_is_missing("https://www.aemo.com.au/x.xlsx") is None
+
+
+def test_pre_check_returns_none_for_non_archive_extensions(_patch_precheck_prefixes, aemo_mock_server):
+    """The pre-check only considers .zip and .csv files — other suffixes
+    fall through (the parent listing wouldn't help us anyway)."""
+    url = f"{aemo_mock_server}/some/dir/file.xlsx"
+    assert downloader._pre_check_file_is_missing(url) is None
+
+
+def test_pre_check_returns_false_when_file_is_listed(_patch_precheck_prefixes, aemo_mock_server):
+    """File present in the parent directory's HTML index → False
+    (i.e. NOT missing). The SimpleHTTPRequestHandler-generated index
+    lists every entry in the directory."""
+    listed = (
+        f"{aemo_mock_server}/Data_Archive/Wholesale_Electricity/MMSDM/2018/"
+        "MMSDM_2018_04/MMSDM_Historical_Data_SQLLoader/DATA/"
+        "PUBLIC_DVD_DISPATCHLOAD_201804010000.zip"
+    )
+    assert downloader._pre_check_file_is_missing(listed) is False
+
+
+def test_pre_check_returns_true_when_file_is_not_listed(_patch_precheck_prefixes, aemo_mock_server):
+    """File absent from the parent directory's HTML index → True
+    (missing). This is the speed-win path."""
+    not_listed = (
+        f"{aemo_mock_server}/Data_Archive/Wholesale_Electricity/MMSDM/2018/"
+        "MMSDM_2018_04/MMSDM_Historical_Data_SQLLoader/DATA/"
+        "PUBLIC_DVD_DOES_NOT_EXIST_201804010000.zip"
+    )
+    assert downloader._pre_check_file_is_missing(not_listed) is True
+
+
+def test_pre_check_returns_none_when_parent_html_unreachable(_patch_precheck_prefixes, aemo_mock_server):
+    """If the parent listing itself 404s, the pre-check returns None so
+    the caller falls through to a real request rather than silently
+    treating the file as missing on a transient infrastructure hiccup."""
+    # /does/not/exist/ doesn't exist as a directory, so the parent
+    # listing request will 404 and download_html_as_soup will raise.
+    orphan = f"{aemo_mock_server}/does/not/exist/foo.zip"
+    assert downloader._pre_check_file_is_missing(orphan) is None
+
+
+def test_download_to_path_raises_http_404_when_pre_check_says_missing(
+    _patch_precheck_prefixes, aemo_mock_server, tmp_path, monkeypatch
+):
+    """When the pre-check confirms a file is missing, download_to_path
+    must raise the same HTTPError shape callers already expect from a
+    real 404 — that's how the existing 404-warning paths in run() etc
+    handle missing months without changing them. Counts session.get
+    calls to prove the wire fetch was skipped."""
+    not_listed = (
+        f"{aemo_mock_server}/Data_Archive/Wholesale_Electricity/MMSDM/2018/"
+        "MMSDM_2018_04/MMSDM_Historical_Data_SQLLoader/DATA/"
+        "PUBLIC_DVD_DOES_NOT_EXIST_201804010000.zip"
+    )
+    # Prime the parent-listing cache so we can isolate the second leg.
+    downloader._pre_check_file_is_missing(not_listed)
+
+    real_get = downloader.session.get
+    call_count = 0
+
+    def counting_get(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return real_get(*args, **kwargs)
+
+    monkeypatch.setattr(downloader.session, "get", counting_get)
+
+    target = tmp_path / "out.zip"
+    with pytest.raises(requests.HTTPError) as exc_info:
+        downloader.download_to_path(not_listed, str(target))
+
+    assert exc_info.value.response.status_code == 404
+    assert call_count == 0, (
+        f"pre-check should skip the wire fetch; saw {call_count} session.get calls"
+    )
+    assert not target.exists(), "no partial output should be left behind"
+
+
+def test_download_to_path_proceeds_when_pre_check_says_present(
+    _patch_precheck_prefixes, aemo_mock_server, tmp_path
+):
+    """A False (present) answer from the pre-check must not short-circuit
+    the real download — otherwise we'd return None bytes."""
+    listed = (
+        f"{aemo_mock_server}/Data_Archive/Wholesale_Electricity/MMSDM/2018/"
+        "MMSDM_2018_04/MMSDM_Historical_Data_SQLLoader/DATA/"
+        "PUBLIC_DVD_DISPATCHLOAD_201804010000.zip"
+    )
+    target = tmp_path / "out.zip"
+    downloaded = downloader.download_to_path(listed, str(target))
+
+    assert downloaded is True
+    assert target.is_file()
+    assert target.stat().st_size > 0

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2024.12.14"
 source = { registry = "https://pypi.org/simple" }
@@ -170,6 +179,7 @@ version = "3.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "cachetools" },
     { name = "feather-format" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -188,6 +198,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
+    { name = "cachetools", specifier = ">=5.5.0" },
     { name = "feather-format", specifier = ">=0.4.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.2.3" },


### PR DESCRIPTION
## Summary

Caches each archive directory's HTML index for ~1 hour and uses it to answer "does this file exist?" locally instead of firing a guaranteed-404 request. Speedup hits whenever a single `dynamic_data_compiler` call scans multiple missing months in the same parent directory (e.g. `start_time` well before `nem_data_model_start_time`).

Smoke-tested against real nemweb:
- 1st missing-file check: ~570ms (parent HTML fetch)
- 2nd+ in same parent: ~10ms (cached)

Effectively the cost of N missing-file checks drops from N×(404 round-trip) to one HTML fetch + N local lookups.

## What's new

- `download_html(url)` / `download_html_as_soup(url)` — TTL-cached helpers (1hr, 1024 entries). Also adopted by `_get_matching_link` and `download_elements_file` for the same caching benefit on the live HTML pages NEMOSIS already fetches.
- `_pre_check_file_is_missing(url)` — returns `True`/`False`/`None` against the parent HTML listing. None means "fall through to a real request" (covers non-nemweb URLs, non-archive extensions, parent HTML unreachable, etc).
- `download_to_path` calls the pre-check; a True answer raises the same `requests.HTTPError(404)` shape as a real 404, so all existing missing-month warning paths keep working unchanged.
- `cachetools>=5.5.0` added to dependencies.
- Autouse fixture in `tests/conftest.py` clears `_html_cache` between tests for hermeticity.

## Tests

8 new tests in `tests/test_downloader.py`:
- `test_download_html_caches_across_calls` — verifies the TTL cache by counting `session.get` calls
- `test_pre_check_returns_none_for_non_nemweb_urls` — protects every existing test that targets the local mock server
- `test_pre_check_returns_none_for_non_archive_extensions` — only `.zip` / `.csv` participate
- `test_pre_check_returns_false_when_file_is_listed` — present in parent HTML → False
- `test_pre_check_returns_true_when_file_is_not_listed` — absent → True
- `test_pre_check_returns_none_when_parent_html_unreachable` — transient infra failure falls through, doesn't suppress real downloads
- `test_download_to_path_raises_http_404_when_pre_check_says_missing` — end-to-end, with a `session.get` counter to prove the wire fetch is skipped
- `test_download_to_path_proceeds_when_pre_check_says_present` — False answer must not short-circuit a real download

## Departures from PR #67

Adapted from Matt's `2a5812f`. Differences:

- **Exception type**: PR #67 raised `ValueError` from the pre-check. This PR raises `requests.HTTPError` with a synthetic 404 response, matching the contract PR #85 established (every download function surfaces a 404 as `HTTPError`). All existing 404-warning callers keep working unchanged.
- **Dropped the `assert file_url.startswith("https://")`** that PR #67 had in the pre-check. The downloader is exercised against `http://` URLs by the offline test fixtures, so an unconditional HTTPS assertion would break the test suite. The pre-check now simply returns None for any URL outside the configured nemweb prefixes — same effect for real callers.
- **Module-level `_html_cache`** exposed so tests can clear it between cases. PR #67's `@cached(cache=TTLCache(...))` decorator-inline pattern would have leaked state across tests.
- **`_NEMWEB_HTML_PRECHECK_PREFIXES`** as a module-level constant (vs. PR #67's inline literal). Lets tests monkeypatch the prefix list to point at the local mock server.

Part of the PR #67 breakdown effort (#8c of ~10).

## Test plan
- [x] `uv run pytest tests/test_downloader.py` — 16/16 pass
- [x] `uv run pytest` — full suite 397 passed / 1 skipped (no regressions)
- [x] Smoke test against real nemweb confirms speed-up
- [ ] CI matrix (3.10–3.14 × ubuntu/windows/macos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)