### PR TITLE
Salvage from PR #52: cache path in error message + docstring fixes

### DIFF
--- a/src/nemosis/data_fetch_methods.py
+++ b/src/nemosis/data_fetch_methods.py
@@ -69,6 +69,7 @@ def dynamic_data_compiler(
         parse_data_types (bool): infers data types of columns when reading
                                  data. default True for API use.
         rebuild (bool): If True then cache files are rebuilt
+                        (redownload, re-unzip, re-convert)
                         even if they exist already. False by default.
         **kwargs: additional arguments passed to the pd.to_{fformat}() function
 
@@ -80,7 +81,9 @@ def dynamic_data_compiler(
         raise UserInputError("The raw_data_location provided is None.")
 
     if not _os.path.isdir(raw_data_location):
-        raise UserInputError("The raw_data_location provided does not exist.")
+        raise UserInputError(
+            f"The raw_data_location {raw_data_location} provided does not exist."
+        )
 
     if table_name not in _defaults.dynamic_tables:
         raise UserInputError("Table name provided is not a dynamic table.")
@@ -201,6 +204,7 @@ def cache_compiler(
                           as object type (compatbile with GUI use). For
                           type inference for a cache, use cache_compiler.
         rebuild (bool): If True then cache files are rebuilt
+                        (redownload, re-unzip, re-convert)
                         even if they exist already. False by default.
         keep_csv (bool): If True, raw CSVs from AEMO are retained
                          alongside the typed feather/parquet after the
@@ -303,7 +307,9 @@ def static_table(
         raise UserInputError("The raw_data_location provided is None.")
 
     if not _os.path.isdir(raw_data_location):
-        raise UserInputError("The raw_data_location provided does not exist.")
+        raise UserInputError(
+            f"The raw_data_location {raw_data_location} provided does not exist."
+        )
 
     if table_name not in _defaults.static_tables:
         raise UserInputError("Table name provided is not a static table.")
@@ -801,7 +807,7 @@ def _determine_columns_and_read_csv(
 def _write_to_format(data, fformat, full_filename, write_kwargs):
     """
     Used by read_data_and_create_file
-    Writes the DataFrame to a non-CSV format is a non_CSV format is specified.
+    Writes the DataFrame to a non-CSV format if a non-CSV format is specified.
     """
     write_function = {"feather": data.to_feather, "parquet": data.to_parquet}
     # Remove files of the same name - deals with case of corrupted files.

--- a/src/nemosis/downloader.py
+++ b/src/nemosis/downloader.py
@@ -428,8 +428,8 @@ def download_unzip_csv(url, down_load_to, keep_zip=False):
 
 def download_csv(url, path_and_name):
     """
-    This function downloads a zipped csv using a url,
-    extracts the csv and saves it a specified location
+    This function downloads a csv using a url,
+    and saves it to a specified location.
     """
     download_to_path(url, path_and_name)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -82,6 +82,26 @@ def test_dynamic_raw_data_location_is_none():
         )
 
 
+def test_dynamic_raw_data_location_missing_includes_path_in_error(tmp_path):
+    """The "does not exist" error must include the offending path so the
+    caller can see exactly what they passed (helps diagnose typos and
+    cwd mistakes). Regression test for the improvement that landed via
+    the doc-strings-and-error-messages cleanup."""
+    bogus = str(tmp_path / "subdir-that-does-not-exist")
+    with pytest.raises(UserInputError, match="subdir-that-does-not-exist"):
+        dynamic_data_compiler(
+            "2018/05/01 00:00:00", "2018/05/01 01:00:00",
+            "DISPATCHPRICE", raw_data_location=bogus,
+        )
+
+
+def test_static_raw_data_location_missing_includes_path_in_error(tmp_path):
+    """Same regression contract for static_table."""
+    bogus = str(tmp_path / "another-missing-dir")
+    with pytest.raises(UserInputError, match="another-missing-dir"):
+        static_table("VARIABLES_FCAS_4_SECOND", raw_data_location=bogus)
+
+
 # ---------------------------------------------------------------------------
 # Argument-validation: cache_compiler
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cherry-picks the salvageable bits from Matt's [PR #52](https://github.com/UNSW-CEEM/NEMOSIS/pull/52) that hadn't been picked up by any of the other PRs in the PR-#67 breakdown. Matt's authorship is preserved on the commit.

What landed:
- Both `"The raw_data_location provided does not exist"` errors now interpolate the actual path — helps diagnose typos and cwd mistakes.
- `rebuild=` docstring clarified with `(redownload, re-unzip, re-convert)`.
- `download_csv` docstring no longer incorrectly describes it as downloading a "zipped csv".
- One `is` → `if` typo in `_write_to_format`'s docstring.

## What was NOT salvaged from PR #52

PR #52 also renamed `download_xl` → `download_xml`. That bit landed differently as `download_xlsx` via PR #84 (the file is `.xlsx`, not XML), so the original direction would have been a step backward.

## Tests

Two new regression tests in `tests/test_errors.py` that assert the offending path appears in the error message — one for `dynamic_data_compiler`, one for `static_table`.

## Test plan
- [x] `uv run pytest tests/test_errors.py` — 18/18 pass
- [x] `uv run pytest` — full suite 409 passed / 1 skipped (no regressions)
- [ ] CI matrix

Closes PR #52 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)