### PR TITLE
Default to parquet + keep_zip=True, refresh README, fix NEXT_DAY URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Python package for downloading historical data published by the Australian Ene
   - [Data from dynamic tables](#data-from-dynamic-tables)
     - [Workflows](#workflows)
       - [Dynamic data compiler](#dynamic-data-compiler)
+        - [Start and end time](#start-and-end-time)
         - [Filter options](#filter-options)
         - [Caching options](#caching-options)
       - [Cache compiler](#cache-compiler)
@@ -100,10 +101,9 @@ Your workflow may determine how you use NEMOSIS. Because the GUI relies on data 
 
 ```python
 from nemosis import dynamic_data_compiler
-from datetime import datetime
 
-start_time = datetime(2017, 1, 1, 0, 0)
-end_time = datetime(2017, 1, 1, 0, 5)
+start_time = '2017/01/01 00:00:00'
+end_time = '2017/01/01 00:05:00'
 table = 'DISPATCHPRICE'
 raw_data_cache = 'C:/Users/your_data_storage'
 
@@ -114,7 +114,29 @@ Using the default settings of `dynamic_data_compiler` will download zip archives
 
 A number of options are available to configure filtering (i.e. what data NEMOSIS returns as a pandas DataFrame) and caching.
 
-For `start_time` and `end_time` you can pass a datetime (timezone unaware), a `date`, or a string of the form "YYYY/MM/DD HH:MM:SS", e.g. `2017/01/01 00:00:00`.
+###### Start and end time
+
+`start_time` and `end_time` accept three forms:
+
+- A string in `"YYYY/MM/DD HH:MM:SS"` form, e.g. `"2017/01/01 00:00:00"`.
+- A `datetime.datetime` (timezone unaware). Timezone-aware datetimes are rejected — NEMOSIS treats all timestamps as AEMO market time.
+- A `datetime.date`. As `start_time` it expands to 00:00:00 of that day; as `end_time` it expands to 00:00:00 of the next day (so `end_time=date(2018, 5, 1)` is inclusive of all of 2018-05-01).
+
+```python
+from datetime import date, datetime
+from nemosis import dynamic_data_compiler
+
+# string
+data = dynamic_data_compiler('2017/01/01 00:00:00', '2017/01/01 00:05:00', table, raw_data_cache)
+
+# datetime
+data = dynamic_data_compiler(datetime(2017, 1, 1, 0, 0), datetime(2017, 1, 1, 0, 5), table, raw_data_cache)
+
+# date (covers all of 2017-01-01)
+data = dynamic_data_compiler(date(2017, 1, 1), date(2017, 1, 1), table, raw_data_cache)
+```
+
+The same forms are accepted by `cache_compiler`.
 
 ###### Filter options
 
@@ -234,8 +256,8 @@ from nemosis import defaults
 
 defaults.table_columns['BIDPEROFFER_D'] += ['PASAAVAILABILITY']
 
-start_time = datetime(2017, 1, 1, 0, 0)
-end_time = datetime(2017, 1, 1, 0, 5)
+start_time = '2017/01/01 00:00:00'
+end_time = '2017/01/01 00:05:00'
 table = 'BIDPEROFFER_D'
 raw_data_cache = 'C:/Users/your_data_storage'
 


### PR DESCRIPTION
## Summary

Seven commits accumulated on the `keep-zip-default-true` branch since master. Grouped by intent:

**Behavioural / default changes**
- `45285d2` (already on remote — origin/keep-zip-default-true tip when this PR was assembled) `keep_zip` default flipped from `False` to `True` for `dynamic_data_compiler` / `cache_compiler`. Closes #56 — cached zips survive between runs.
- `1f034a7` `fformat` default flipped from `feather` to `parquet`. Feather still supported via `fformat='feather'`. Includes README + test-suite updates so the offline suite stays green.

**Fixture / source bug fix**
- `6e65ea5` Fix `NEXT_DAY_DISPATCHLOAD` URL after AEMO renamed the parent directory + bump the `recent` fixture era to 2026-05-15.
- `fdb0b60` Extend the test fixture matrix with a `2026-04` era so the boundary tests carry general recent-month coverage in the `PUBLIC_ARCHIVE#` format.

**Docs**
- `30eba59` Sync README with the caching defaults already on master (`keep_csv=False`, `keep_zip=True`). The previous README still claimed `keep_csv=True`. Added the `keep_csv` × `keep_zip` retention matrix.
- `cea80f0` Fix incorrect "GUI co-use needs `keep_csv=True`" claim. The GUI reads parquet/feather, not the raw AEMO CSV — `keep_csv` is purely for external CSV consumers.
- `679f598` Drop a dangling rationale clause from one matrix row so the matrix is symmetric (just describes contents; the "leanest" / "full" markers stay on rows 2 and 4).
- `53c1b66` New "Start and end time" subsection documenting the three accepted input forms (string, `datetime.datetime`, `datetime.date`) with a code example for each. Includes the `date`-expansion edge case (`end_time` as a bare date is inclusive of the whole day).

## Test plan

- [ ] CI green on the branch
- [ ] Spot-check the rendered README (matrix, new Start-and-end-time section, TOC anchors)
- [ ] Optional: live smoke test against real AEMO/nemweb for `NEXT_DAY_DISPATCHLOAD` (offline suite already covers the URL-fix path via fixtures)
- [ ] Confirm `dynamic_data_compiler` with no explicit `fformat` now writes parquet to a fresh cache directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)